### PR TITLE
Leveling

### DIFF
--- a/lib/di.dart
+++ b/lib/di.dart
@@ -2,6 +2,7 @@ import 'package:get_it/get_it.dart';
 import 'package:http/http.dart' as http;
 import 'package:quiz_master/core/presentation/blocs/page_index_cubit.dart';
 import 'package:quiz_master/core/presentation/blocs/theme_cubit.dart';
+import 'package:quiz_master/features/leveling/presentation/blocs/user_level/user_level_bloc.dart';
 import 'package:quiz_master/features/quiz/data/datasource/quiz_remote_data_source.dart';
 import 'package:quiz_master/features/quiz/data/repository/quiz_repository_impl.dart';
 import 'package:quiz_master/features/quiz/domain/repository/quiz_repository.dart';
@@ -24,4 +25,5 @@ void setup() {
 
   sl.registerLazySingleton(() => ThemeCubit());
   sl.registerLazySingleton(() => PageIndexCubit());
+  sl.registerLazySingleton(() => UserLevelBloc());
 }

--- a/lib/features/browse/presentation/pages/browse_page.dart
+++ b/lib/features/browse/presentation/pages/browse_page.dart
@@ -1,17 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:quiz_master/core/presentation/widgets/responsive.dart';
 import 'package:quiz_master/core/presentation/widgets/theme_toggle_button.dart';
-import 'package:quiz_master/features/home/presentation/widgets/categories_section.dart';
-import 'package:quiz_master/features/home/presentation/widgets/home_page_footer.dart';
-import 'package:quiz_master/features/home/presentation/widgets/home_page_header.dart';
-import 'package:quiz_master/features/home/presentation/widgets/info_card_section.dart';
-import 'package:quiz_master/features/home/presentation/widgets/quick_play_button.dart';
 import 'package:quiz_master/features/leveling/presentation/widgets/level_card.dart';
 import 'package:quiz_master/l10n/app_localizations.dart';
 import 'package:quiz_master/utils/helpers.dart';
 
-class HomePage extends StatelessWidget {
-  const HomePage({super.key});
+class BrowsePage extends StatelessWidget {
+  const BrowsePage({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -76,14 +71,7 @@ class HomePage extends StatelessWidget {
             child: Center(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  HomePageHeader(),
-                  QuickPlayButton(),
-                  const SizedBox(height: 24),
-                  InfoCardsSection(),
-                  const CategoriesSection(),
-                  const HomePageFooter(),
-                ],
+                children: [],
               ),
             ),
           ),

--- a/lib/features/home/presentation/pages/home_page.dart
+++ b/lib/features/home/presentation/pages/home_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:quiz_master/core/presentation/widgets/responsive.dart';
 import 'package:quiz_master/core/presentation/widgets/theme_toggle_button.dart';
 import 'package:quiz_master/features/home/presentation/widgets/categories_section.dart';
 import 'package:quiz_master/features/home/presentation/widgets/home_page_footer.dart';
 import 'package:quiz_master/features/home/presentation/widgets/home_page_header.dart';
 import 'package:quiz_master/features/home/presentation/widgets/info_card_section.dart';
 import 'package:quiz_master/features/home/presentation/widgets/quick_play_button.dart';
+import 'package:quiz_master/features/leveling/presentation/widgets/level_card.dart';
 import 'package:quiz_master/l10n/app_localizations.dart';
 import 'package:quiz_master/utils/helpers.dart';
 
@@ -18,7 +20,11 @@ class HomePage extends StatelessWidget {
         animateColor: true,
         title: Padding(
           padding: EdgeInsets.only(
-            left: MediaQuery.of(context).size.width * 0.15,
+            left: Responsive.isMobile(context)
+                ? 0
+                : Responsive.isTablet(context)
+                ? 16
+                : MediaQuery.of(context).size.width * 0.15,
           ),
           child: ShaderMask(
             shaderCallback: (bounds) => const LinearGradient(
@@ -36,9 +42,23 @@ class HomePage extends StatelessWidget {
           ),
         ),
         actionsPadding: EdgeInsets.only(
-          right: MediaQuery.of(context).size.width * 0.15,
+          right: Responsive.isMobile(context)
+              ? 0
+              : Responsive.isTablet(context)
+              ? 16
+              : MediaQuery.of(context).size.width * 0.15,
         ),
-        actions: [ThemeToggleButton()],
+        actions: [
+          ThemeToggleButton(),
+          SizedBox(
+            width: Responsive.isMobile(context)
+                ? 6
+                : Responsive.isTablet(context)
+                ? 8
+                : 16,
+          ),
+          LevelCard(),
+        ],
       ),
       body: Container(
         decoration: BoxDecoration(

--- a/lib/features/home/presentation/widgets/categories_section.dart
+++ b/lib/features/home/presentation/widgets/categories_section.dart
@@ -1,11 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:quiz_master/core/presentation/widgets/responsive.dart';
-import 'package:quiz_master/di.dart';
+import 'package:quiz_master/features/leveling/presentation/pages/leveling_difficulty_page.dart';
 import 'package:quiz_master/features/quiz/data/constants/categories.dart';
-import 'package:quiz_master/features/quiz/domain/entity/quiz_params.dart';
-import 'package:quiz_master/features/quiz/presentation/blocs/quiz/quiz_cubit.dart';
-import 'package:quiz_master/features/quiz/presentation/pages/quiz_page.dart';
 import 'package:quiz_master/l10n/app_localizations.dart';
 import 'package:quiz_master/utils/helpers.dart';
 
@@ -174,13 +170,8 @@ class _AnimatedCategoryCardState extends State<_AnimatedCategoryCard>
           Navigator.push(
             context,
             MaterialPageRoute(
-              builder: (_) => BlocProvider(
-                create: (_) => sl<QuizCubit>()
-                  ..loadQuiz(
-                    QuizParams(amount: 10, category: widget.category.id),
-                  ),
-                child: QuizPage(),
-              ),
+              builder: (_) =>
+                  LevelingDifficultyPage(category: widget.category.id),
             ),
           );
         },

--- a/lib/features/home/presentation/widgets/quick_play_button.dart
+++ b/lib/features/home/presentation/widgets/quick_play_button.dart
@@ -1,11 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:quiz_master/core/presentation/widgets/responsive.dart';
-import 'package:quiz_master/di.dart';
-import 'package:quiz_master/features/quiz/domain/entity/quiz_params.dart';
-import 'package:quiz_master/features/quiz/presentation/blocs/quiz/quiz_cubit.dart';
-import 'package:quiz_master/features/quiz/presentation/pages/quiz_page.dart';
+import 'package:quiz_master/features/leveling/presentation/pages/leveling_difficulty_page.dart';
 import 'package:quiz_master/l10n/app_localizations.dart';
 
 class QuickPlayButton extends StatefulWidget {
@@ -85,13 +81,7 @@ class _QuickPlayButtonState extends State<QuickPlayButton>
                 onPressed: () {
                   Navigator.push(
                     context,
-                    MaterialPageRoute(
-                      builder: (_) => BlocProvider(
-                        create: (_) =>
-                            sl<QuizCubit>()..loadQuiz(QuizParams(amount: 10)),
-                        child: QuizPage(),
-                      ),
-                    ),
+                    MaterialPageRoute(builder: (_) => LevelingDifficultyPage()),
                   );
                 },
                 icon: const FaIcon(FontAwesomeIcons.bolt, size: 24),

--- a/lib/features/leveling/data/constants/difficulties.dart
+++ b/lib/features/leveling/data/constants/difficulties.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:quiz_master/l10n/app_localizations.dart';
+
+class Difficulties {
+  final String title;
+  final double multiplier;
+  final String description;
+  final IconData icon;
+  final String apiValue;
+
+  const Difficulties(
+    this.title,
+    this.multiplier,
+    this.description,
+    this.icon,
+    this.apiValue,
+  );
+}
+
+List<Difficulties> getDifficulties(BuildContext context) {
+  return [
+    Difficulties(
+      AppLocalizations.of(context)!.difficultyEasy,
+      1.0,
+      AppLocalizations.of(context)!.difficultyEasyDescription,
+      FontAwesomeIcons.brain,
+      "easy",
+    ),
+    Difficulties(
+      AppLocalizations.of(context)!.difficultyMedium,
+      1.5,
+      AppLocalizations.of(context)!.difficultyMediumDescription,
+      FontAwesomeIcons.bolt,
+      "medium",
+    ),
+    Difficulties(
+      AppLocalizations.of(context)!.difficultyHard,
+      2.0,
+      AppLocalizations.of(context)!.difficultyHardDescription,
+      FontAwesomeIcons.fireFlameCurved,
+      "hard",
+    ),
+  ];
+}

--- a/lib/features/leveling/presentation/blocs/user_level/user_level_bloc.dart
+++ b/lib/features/leveling/presentation/blocs/user_level/user_level_bloc.dart
@@ -1,0 +1,42 @@
+import 'dart:math';
+import 'package:equatable/equatable.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+part 'user_level_event.dart';
+part 'user_level_state.dart';
+
+class UserLevelBloc extends HydratedBloc<UserLevelEvent, UserLevelState> {
+  final int baseXp;
+  final double exponent;
+
+  UserLevelBloc({this.baseXp = 100, this.exponent = 1.3})
+    : super(const UserLevelState()) {
+    on<AddXp>(_onAddXp);
+    on<ResetLevel>(_onResetLevel);
+  }
+
+  int xpToNextLevel(int level) => (baseXp * pow(level, exponent)).round();
+
+  void _onAddXp(AddXp event, Emitter<UserLevelState> emit) {
+    int newXp = state.currentXp + event.xp;
+    int newLevel = state.level;
+
+    while (newXp >= xpToNextLevel(newLevel)) {
+      newXp -= xpToNextLevel(newLevel);
+      newLevel += 1;
+    }
+
+    emit(state.copyWith(level: newLevel, currentXp: newXp));
+  }
+
+  void _onResetLevel(ResetLevel event, Emitter<UserLevelState> emit) {
+    emit(const UserLevelState());
+  }
+
+  @override
+  UserLevelState? fromJson(Map<String, dynamic> json) =>
+      UserLevelState.fromJson(json);
+
+  @override
+  Map<String, dynamic>? toJson(UserLevelState state) => state.toJson();
+}

--- a/lib/features/leveling/presentation/blocs/user_level/user_level_event.dart
+++ b/lib/features/leveling/presentation/blocs/user_level/user_level_event.dart
@@ -1,0 +1,19 @@
+part of 'user_level_bloc.dart';
+
+abstract class UserLevelEvent extends Equatable {
+  const UserLevelEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AddXp extends UserLevelEvent {
+  final int xp;
+
+  const AddXp(this.xp);
+
+  @override
+  List<Object?> get props => [xp];
+}
+
+class ResetLevel extends UserLevelEvent {}

--- a/lib/features/leveling/presentation/blocs/user_level/user_level_state.dart
+++ b/lib/features/leveling/presentation/blocs/user_level/user_level_state.dart
@@ -1,0 +1,27 @@
+part of 'user_level_bloc.dart';
+
+class UserLevelState extends Equatable {
+  final int level;
+  final int currentXp;
+
+  const UserLevelState({this.level = 1, this.currentXp = 0});
+
+  @override
+  List<Object> get props => [level, currentXp];
+
+  UserLevelState copyWith({int? level, int? currentXp}) {
+    return UserLevelState(
+      level: level ?? this.level,
+      currentXp: currentXp ?? this.currentXp,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {'level': level, 'currentXp': currentXp};
+
+  static UserLevelState fromJson(Map<String, dynamic> json) {
+    return UserLevelState(
+      level: json['level'] as int? ?? 1,
+      currentXp: json['currentXp'] as int? ?? 0,
+    );
+  }
+}

--- a/lib/features/leveling/presentation/pages/leveling_difficulty_page.dart
+++ b/lib/features/leveling/presentation/pages/leveling_difficulty_page.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:quiz_master/core/presentation/widgets/responsive.dart';
+import 'package:quiz_master/features/leveling/data/constants/difficulties.dart';
+import 'package:quiz_master/features/leveling/presentation/widgets/difficulty_card.dart';
+import 'package:quiz_master/features/quiz/presentation/widgets/home_button.dart';
+import 'package:quiz_master/l10n/app_localizations.dart';
+import 'package:quiz_master/utils/helpers.dart';
+
+class LevelingDifficultyPage extends StatelessWidget {
+  final int? category;
+  const LevelingDifficultyPage({super.key, this.category});
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Difficulties> difficulties = getDifficulties(context);
+    return Scaffold(
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: Helpers.isDarkMode(context)
+              ? const LinearGradient(
+                  colors: [Color(0xFF000000), Color(0xFF2E1A3F)],
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                )
+              : null,
+        ),
+        child: SizedBox.expand(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Center(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    AppLocalizations.of(context)!.chooseYourDifficulty,
+                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 48),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 900),
+                    child: Text(
+                      AppLocalizations.of(context)!.chooseYourDifficultyDesc,
+                      style: TextStyle(
+                        fontSize: 24,
+                        color: Colors.grey.shade500,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 900),
+                    child: Responsive(
+                      mobile: _buildGrid(context, 1, difficulties, category),
+                      tablet: _buildGrid(context, 3, difficulties, category),
+                      desktop: _buildGrid(context, 3, difficulties, category),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  HomeButton(),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGrid(
+    BuildContext context,
+    int columns,
+    List<Difficulties> difficulties,
+    int? category,
+  ) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final totalSpacing = (columns - 1) * 16;
+        final itemWidth = (constraints.maxWidth - totalSpacing) / columns;
+
+        return Wrap(
+          spacing: 16,
+          runSpacing: 16,
+          children: List.generate(difficulties.length, (index) {
+            final delay = Duration(milliseconds: 150 * index);
+            return SizedBox(
+              width: itemWidth,
+              child: DifficultyCard(
+                difficulty: difficulties[index],
+                delay: delay,
+                category: category,
+                iconColor: index == 0
+                    ? Colors.green
+                    : index == 1
+                    ? Colors.yellow
+                    : Colors.red,
+              ),
+            );
+          }),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/leveling/presentation/widgets/difficulty_card.dart
+++ b/lib/features/leveling/presentation/widgets/difficulty_card.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:quiz_master/di.dart';
+import 'package:quiz_master/features/leveling/data/constants/difficulties.dart';
+import 'package:quiz_master/features/quiz/domain/entity/quiz_params.dart';
+import 'package:quiz_master/features/quiz/presentation/blocs/quiz/quiz_cubit.dart';
+import 'package:quiz_master/features/quiz/presentation/pages/quiz_page.dart';
+import 'package:quiz_master/utils/extensions.dart';
+import 'package:quiz_master/utils/helpers.dart';
+
+class DifficultyCard extends StatefulWidget {
+  final Difficulties difficulty;
+  final Color iconColor;
+  final Duration delay;
+  final int? category;
+
+  const DifficultyCard({
+    super.key,
+    required this.difficulty,
+    required this.delay,
+    required this.iconColor,
+    this.category,
+  });
+
+  @override
+  State<DifficultyCard> createState() => _DifficultyCardState();
+}
+
+class _DifficultyCardState extends State<DifficultyCard>
+    with SingleTickerProviderStateMixin {
+  bool _pressed = false;
+  bool _hovering = false;
+  bool _visible = false;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(widget.delay, () {
+      if (mounted) setState(() => _visible = true);
+    });
+  }
+
+  void _handleTapDown(TapDownDetails _) {
+    setState(() => _pressed = true);
+  }
+
+  void _handleTapUp(TapUpDetails _) {
+    Future.delayed(const Duration(milliseconds: 100), () {
+      if (mounted) setState(() => _pressed = false);
+    });
+  }
+
+  void _handleTapCancel() {
+    setState(() => _pressed = false);
+  }
+
+  double get _scale {
+    double scale = 1.0;
+    if (_hovering) scale *= 1.1;
+    if (_pressed) scale *= 0.9;
+    return scale;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSlide(
+      offset: _visible ? Offset.zero : const Offset(0, 0.2),
+      duration: const Duration(milliseconds: 600),
+      curve: Curves.easeOutCubic,
+      child: AnimatedOpacity(
+        opacity: _visible ? 1 : 0,
+        duration: const Duration(milliseconds: 600),
+        curve: Curves.easeOut,
+        child: MouseRegion(
+          onEnter: (_) => setState(() => _hovering = true),
+          onExit: (_) => setState(() => _hovering = false),
+          child: GestureDetector(
+            onTapDown: _handleTapDown,
+            onTapUp: _handleTapUp,
+            onTapCancel: _handleTapCancel,
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => BlocProvider(
+                    create: (_) => sl<QuizCubit>()
+                      ..loadQuiz(
+                        QuizParams(
+                          amount: widget.difficulty.questionCount,
+                          category: widget.category,
+                          difficulty: widget.difficulty.apiValue,
+                        ),
+                      ),
+                    child: QuizPage(difficulty: widget.difficulty),
+                  ),
+                ),
+              );
+            },
+            child: AnimatedScale(
+              scale: _scale,
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeOutBack,
+              child: Card(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                  side: BorderSide(
+                    color: _hovering || _pressed
+                        ? Colors.deepPurpleAccent
+                        : Colors.grey.shade500,
+                    width: 0.5,
+                  ),
+                ),
+                elevation: _hovering || _pressed ? 1 : 0,
+                color: Helpers.isDarkMode(context)
+                    ? Colors.white.withAlpha(10)
+                    : Colors.white,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 24,
+                    horizontal: 16,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      FaIcon(
+                        widget.difficulty.icon,
+                        size: 48,
+                        color: widget.iconColor,
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        widget.difficulty.title,
+                        style: const TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        "${widget.difficulty.multiplier}x XP",
+                        style: TextStyle(
+                          fontSize: 18,
+                          color: Colors.deepPurpleAccent,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        widget.difficulty.description,
+                        style: TextStyle(
+                          fontSize: 18,
+                          color: Colors.grey.shade500,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/leveling/presentation/widgets/level_card.dart
+++ b/lib/features/leveling/presentation/widgets/level_card.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:quiz_master/di.dart';
+import 'package:quiz_master/features/leveling/presentation/blocs/user_level/user_level_bloc.dart';
+import 'package:quiz_master/l10n/app_localizations.dart';
+
+class LevelCard extends StatelessWidget {
+  const LevelCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<UserLevelBloc, UserLevelState>(
+      bloc: sl<UserLevelBloc>(),
+      builder: (context, state) {
+        final xpToNext = sl<UserLevelBloc>().xpToNextLevel(state.level);
+        final progress = (state.currentXp / xpToNext).clamp(0.0, 1.0);
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          margin: const EdgeInsets.only(right: 8),
+          constraints: const BoxConstraints(maxHeight: kToolbarHeight),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  const FaIcon(
+                    FontAwesomeIcons.trophy,
+                    color: Colors.amber,
+                    size: 24,
+                  ),
+                  Positioned(
+                    right: -2,
+                    top: -2,
+                    child: Container(
+                      padding: const EdgeInsets.all(1),
+                      decoration: const BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: Colors.white,
+                      ),
+                      child: const FaIcon(
+                        FontAwesomeIcons.solidStar,
+                        color: Colors.orange,
+                        size: 8,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(width: 6),
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    AppLocalizations.of(context)!.level,
+                    style: TextStyle(
+                      color: Colors.purpleAccent,
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    '${state.level}',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(width: 8),
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        '${state.currentXp} XP',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                      const SizedBox(width: 4),
+                      const Text('/', style: TextStyle(fontSize: 10)),
+                      const SizedBox(width: 4),
+                      Text('$xpToNext XP', style: TextStyle(fontSize: 12)),
+                    ],
+                  ),
+                  const SizedBox(height: 2),
+                  SizedBox(
+                    width: 60,
+                    height: 6,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(3),
+                      child: LinearProgressIndicator(
+                        value: progress,
+                        backgroundColor: Theme.of(
+                          context,
+                        ).colorScheme.surfaceContainerHighest,
+                        valueColor: const AlwaysStoppedAnimation<Color>(
+                          Colors.deepPurpleAccent,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/quiz/presentation/blocs/quiz_run/quiz_run_cubit.dart
+++ b/lib/features/quiz/presentation/blocs/quiz_run/quiz_run_cubit.dart
@@ -45,6 +45,9 @@ class QuizRunCubit extends Cubit<QuizRunState> {
   }
 
   void answer(String answer) {
+    if (state.isLocked) return;
+    _timer?.cancel();
+
     final q = state.questions[state.currentIndex];
     final isCorrect = answer == q.correctAnswer;
 
@@ -63,12 +66,15 @@ class QuizRunCubit extends Cubit<QuizRunState> {
 
     emit(
       state.copyWith(
+        isLocked: true,
+        selectedAnswer: answer,
         score: isCorrect ? state.score + 1 : state.score,
         userAnswers: updatedAnswers,
       ),
     );
-
-    nextQuestion();
+    Future.delayed(const Duration(seconds: 1), () {
+      nextQuestion();
+    });
   }
 
   void nextQuestion() {
@@ -77,6 +83,8 @@ class QuizRunCubit extends Cubit<QuizRunState> {
         state.copyWith(
           currentIndex: state.currentIndex + 1,
           disabledAnswers: [],
+          isLocked: false,
+          selectedAnswer: null,
         ),
       );
       _startTimer();

--- a/lib/features/quiz/presentation/blocs/quiz_run/quiz_run_cubit.dart
+++ b/lib/features/quiz/presentation/blocs/quiz_run/quiz_run_cubit.dart
@@ -6,17 +6,19 @@ import 'package:quiz_master/features/quiz/presentation/blocs/quiz_run/quiz_run_s
 
 class QuizRunCubit extends Cubit<QuizRunState> {
   Timer? _timer;
-  int _questionStartTime = 30;
+  int _questionStartTime = 20;
 
-  QuizRunCubit(List<Question> questions)
-    : super(QuizRunState(questions: questions)) {
+  QuizRunCubit(List<Question> questions, int timePerQuestion)
+    : super(
+        QuizRunState(questions: questions, timePerQuestion: timePerQuestion),
+      ) {
     _startTimer();
   }
 
   void _startTimer() {
     _timer?.cancel();
-    emit(state.copyWith(timeLeft: 30));
-    _questionStartTime = 30;
+    emit(state.copyWith(timeLeft: state.timePerQuestion));
+    _questionStartTime = state.timePerQuestion;
 
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
       if (state.timeLeft > 1) {

--- a/lib/features/quiz/presentation/blocs/quiz_run/quiz_run_state.dart
+++ b/lib/features/quiz/presentation/blocs/quiz_run/quiz_run_state.dart
@@ -8,6 +8,7 @@ class QuizRunState {
   final bool lifelineFiftyFiftyAvailable;
   final bool lifelineSkipAvailable;
   final bool showResults;
+  final int timePerQuestion;
 
   final List<String> disabledAnswers;
 
@@ -27,6 +28,7 @@ class QuizRunState {
     this.totalElapsedTime = Duration.zero,
     this.answerTimes = const [],
     this.userAnswers = const [],
+    this.timePerQuestion = 20,
   });
 
   QuizRunState copyWith({
@@ -41,6 +43,7 @@ class QuizRunState {
     Duration? totalElapsedTime,
     List<int>? answerTimes,
     List<String?>? userAnswers,
+    int? timePerQuestion,
   }) {
     return QuizRunState(
       questions: questions ?? this.questions,
@@ -56,6 +59,7 @@ class QuizRunState {
       totalElapsedTime: totalElapsedTime ?? this.totalElapsedTime,
       answerTimes: answerTimes ?? this.answerTimes,
       userAnswers: userAnswers ?? this.userAnswers,
+      timePerQuestion: timePerQuestion ?? this.timePerQuestion,
     );
   }
 }

--- a/lib/features/quiz/presentation/blocs/quiz_run/quiz_run_state.dart
+++ b/lib/features/quiz/presentation/blocs/quiz_run/quiz_run_state.dart
@@ -9,6 +9,8 @@ class QuizRunState {
   final bool lifelineSkipAvailable;
   final bool showResults;
   final int timePerQuestion;
+  final bool isLocked;
+  final String? selectedAnswer;
 
   final List<String> disabledAnswers;
 
@@ -29,6 +31,8 @@ class QuizRunState {
     this.answerTimes = const [],
     this.userAnswers = const [],
     this.timePerQuestion = 20,
+    this.isLocked = false,
+    this.selectedAnswer,
   });
 
   QuizRunState copyWith({
@@ -44,6 +48,8 @@ class QuizRunState {
     List<int>? answerTimes,
     List<String?>? userAnswers,
     int? timePerQuestion,
+    bool? isLocked,
+    String? selectedAnswer,
   }) {
     return QuizRunState(
       questions: questions ?? this.questions,
@@ -60,6 +66,8 @@ class QuizRunState {
       answerTimes: answerTimes ?? this.answerTimes,
       userAnswers: userAnswers ?? this.userAnswers,
       timePerQuestion: timePerQuestion ?? this.timePerQuestion,
+      isLocked: isLocked ?? this.isLocked,
+      selectedAnswer: selectedAnswer ?? this.selectedAnswer,
     );
   }
 }

--- a/lib/features/quiz/presentation/pages/quiz_page.dart
+++ b/lib/features/quiz/presentation/pages/quiz_page.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:quiz_master/features/leveling/data/constants/difficulties.dart';
 import 'package:quiz_master/features/quiz/presentation/blocs/quiz/quiz_cubit.dart';
 import 'package:quiz_master/features/quiz/presentation/blocs/quiz_run/quiz_run_cubit.dart';
 import 'package:quiz_master/features/quiz/presentation/pages/quiz_run_page.dart';
 import 'package:quiz_master/l10n/app_localizations.dart';
+import 'package:quiz_master/utils/extensions.dart';
 import 'package:quiz_master/utils/helpers.dart';
 
 class QuizPage extends StatelessWidget {
-  const QuizPage({super.key});
+  final Difficulties difficulty;
+  const QuizPage({super.key, required this.difficulty});
 
   @override
   Widget build(BuildContext context) {
@@ -34,8 +37,11 @@ class QuizPage extends StatelessWidget {
                 );
               } else if (state is QuizLoaded) {
                 return BlocProvider(
-                  create: (_) => QuizRunCubit(state.questions),
-                  child: QuizRunPage(),
+                  create: (_) => QuizRunCubit(
+                    state.questions,
+                    difficulty.timePerQuestion.inSeconds,
+                  ),
+                  child: QuizRunPage(difficulty: difficulty),
                 );
               } else if (state is QuizError) {
                 return Center(

--- a/lib/features/quiz/presentation/pages/quiz_run_page.dart
+++ b/lib/features/quiz/presentation/pages/quiz_run_page.dart
@@ -1,18 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:quiz_master/features/leveling/data/constants/difficulties.dart';
 import 'package:quiz_master/features/quiz/presentation/blocs/quiz_run/quiz_run_cubit.dart';
 import 'package:quiz_master/features/quiz/presentation/blocs/quiz_run/quiz_run_state.dart';
 import 'package:quiz_master/features/quiz/presentation/widgets/animated_answer_card.dart';
-import 'package:quiz_master/features/quiz/presentation/widgets/hover_chip.dart'
-    show HoverChip;
+import 'package:quiz_master/features/quiz/presentation/widgets/hover_chip.dart';
 import 'package:quiz_master/features/quiz/presentation/widgets/question_card_wrapper.dart';
 import 'package:quiz_master/l10n/app_localizations.dart';
+import 'package:quiz_master/utils/extensions.dart';
 
 import '../widgets/quiz_summary.dart';
 
 class QuizRunPage extends StatelessWidget {
-  const QuizRunPage({super.key});
+  final Difficulties difficulty;
+  const QuizRunPage({super.key, required this.difficulty});
 
   @override
   Widget build(BuildContext context) {
@@ -34,19 +36,20 @@ class QuizRunPage extends StatelessWidget {
         final currentQuestion = state.currentIndex + 1;
 
         final questionProgress = currentQuestion / totalQuestions;
-        final timeProgress = state.timeLeft / 30;
+        final timeProgress =
+            state.timeLeft / difficulty.timePerQuestion.inSeconds;
 
         return SafeArea(
           child: SizedBox.expand(
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 900),
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      Row(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Center(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 900),
+                      child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
                           Text(
@@ -77,8 +80,11 @@ class QuizRunPage extends StatelessWidget {
                           ),
                         ],
                       ),
-                      const SizedBox(height: 12),
-                      TweenAnimationBuilder<double>(
+                    ),
+                    const SizedBox(height: 12),
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 900),
+                      child: TweenAnimationBuilder<double>(
                         tween: Tween<double>(begin: 0, end: questionProgress),
                         duration: const Duration(milliseconds: 500),
                         curve: Curves.easeOut,
@@ -92,8 +98,11 @@ class QuizRunPage extends StatelessWidget {
                           );
                         },
                       ),
-                      const SizedBox(height: 6),
-                      TweenAnimationBuilder<double>(
+                    ),
+                    const SizedBox(height: 6),
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 900),
+                      child: TweenAnimationBuilder<double>(
                         tween: Tween<double>(begin: 0, end: timeProgress),
                         duration: const Duration(milliseconds: 500),
                         builder: (context, value, child) {
@@ -106,8 +115,11 @@ class QuizRunPage extends StatelessWidget {
                           );
                         },
                       ),
-                      const SizedBox(height: 24),
-                      Row(
+                    ),
+                    const SizedBox(height: 24),
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 900),
+                      child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
                           HoverChip(
@@ -131,14 +143,20 @@ class QuizRunPage extends StatelessWidget {
                           ),
                         ],
                       ),
-                      const SizedBox(height: 24),
-                      QuestionCardWrapper(
+                    ),
+                    const SizedBox(height: 24),
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 900),
+                      child: QuestionCardWrapper(
                         key: ValueKey(state.currentIndex),
                         question: question.question,
                         exitDuration: const Duration(milliseconds: 500),
                       ),
-                      const SizedBox(height: 24),
-                      Column(
+                    ),
+                    const SizedBox(height: 24),
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 900),
+                      child: Column(
                         children: List.generate(
                           question.shuffledAnswers.length,
                           (index) {
@@ -157,8 +175,8 @@ class QuizRunPage extends StatelessWidget {
                           },
                         ),
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ),
             ),

--- a/lib/features/quiz/presentation/pages/quiz_run_page.dart
+++ b/lib/features/quiz/presentation/pages/quiz_run_page.dart
@@ -28,6 +28,7 @@ class QuizRunPage extends StatelessWidget {
             answerTimes: state.answerTimes,
             questions: state.questions,
             userAnswers: state.userAnswers,
+            difficulty: difficulty,
           );
         }
 
@@ -167,7 +168,9 @@ class QuizRunPage extends StatelessWidget {
                               key: ValueKey('${state.currentIndex}_$answer'),
                               index: index,
                               label: label,
+                              isSelected: state.selectedAnswer == answer,
                               answer: answer,
+                              isLocked: state.isLocked,
                               disabled: state.disabledAnswers.contains(answer),
                               onTap: () =>
                                   context.read<QuizRunCubit>().answer(answer),

--- a/lib/features/quiz/presentation/widgets/animated_answer_card.dart
+++ b/lib/features/quiz/presentation/widgets/animated_answer_card.dart
@@ -7,6 +7,8 @@ class AnimatedAnswerCard extends StatefulWidget {
   final bool disabled;
   final VoidCallback? onTap;
   final int index;
+  final bool isLocked;
+  final bool isSelected;
 
   const AnimatedAnswerCard({
     super.key,
@@ -15,6 +17,8 @@ class AnimatedAnswerCard extends StatefulWidget {
     this.disabled = false,
     this.onTap,
     required this.index,
+    required this.isLocked,
+    required this.isSelected,
   });
 
   @override
@@ -65,7 +69,8 @@ class _AnimatedAnswerCardState extends State<AnimatedAnswerCard>
         child: AnswerCard(
           label: widget.label,
           answer: widget.answer,
-          disabled: widget.disabled,
+          isSelected: widget.isSelected,
+          disabled: widget.disabled || widget.isLocked,
           onTap: widget.onTap,
         ),
       ),

--- a/lib/features/quiz/presentation/widgets/answer_card.dart
+++ b/lib/features/quiz/presentation/widgets/answer_card.dart
@@ -6,6 +6,7 @@ class AnswerCard extends StatefulWidget {
   final String label;
   final bool disabled;
   final VoidCallback? onTap;
+  final bool isSelected;
 
   const AnswerCard({
     super.key,
@@ -13,6 +14,7 @@ class AnswerCard extends StatefulWidget {
     required this.label,
     this.disabled = false,
     this.onTap,
+    required this.isSelected,
   });
 
   @override
@@ -30,15 +32,23 @@ class _AnswerCardState extends State<AnswerCard> {
 
   @override
   Widget build(BuildContext context) {
-    final bgColor = widget.disabled
+    final bgColor = widget.isSelected
+        ? Colors.deepPurpleAccent
+        : widget.disabled
         ? null
         : _hovering
-        ? Helpers.isDarkMode(context)
-              ? Colors.teal
-              : Colors.teal.shade300
+        ? Colors.purpleAccent
         : Helpers.isDarkMode(context)
         ? Colors.black.withAlpha(150)
         : Colors.white;
+
+    final answerColor = widget.isSelected
+        ? Colors.greenAccent
+        : widget.disabled
+        ? Colors.grey.shade500
+        : _hovering
+        ? Colors.amberAccent
+        : Colors.indigoAccent;
 
     return MouseRegion(
       onEnter: (_) => _setHover(true),
@@ -67,9 +77,7 @@ class _AnswerCardState extends State<AnswerCard> {
               Text(
                 widget.label,
                 style: TextStyle(
-                  color: widget.disabled
-                      ? Colors.grey.shade500
-                      : Colors.deepPurpleAccent,
+                  color: answerColor,
                   fontWeight: FontWeight.bold,
                   fontSize: 20,
                 ),
@@ -79,7 +87,7 @@ class _AnswerCardState extends State<AnswerCard> {
                 child: Text(
                   widget.answer,
                   style: TextStyle(
-                    color: widget.disabled
+                    color: widget.disabled && !widget.isSelected
                         ? Colors.grey.shade500
                         : Helpers.isDarkMode(context)
                         ? Colors.white

--- a/lib/features/quiz/presentation/widgets/home_button.dart
+++ b/lib/features/quiz/presentation/widgets/home_button.dart
@@ -39,7 +39,8 @@ class HomeButtonState extends State<HomeButton> {
           AppLocalizations.of(context)!.home,
           style: const TextStyle(fontSize: 14),
         ),
-        onPressed: () => Navigator.of(context).pop(),
+        onPressed: () =>
+            Navigator.of(context).popUntil((route) => route.isFirst),
       ),
     );
   }

--- a/lib/features/quiz/presentation/widgets/quiz_summary.dart
+++ b/lib/features/quiz/presentation/widgets/quiz_summary.dart
@@ -1,16 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:quiz_master/di.dart';
+import 'package:quiz_master/features/leveling/presentation/pages/leveling_difficulty_page.dart';
 import 'package:quiz_master/features/quiz/domain/entity/question.dart';
-import 'package:quiz_master/features/quiz/domain/entity/quiz_params.dart';
-import 'package:quiz_master/features/quiz/presentation/blocs/quiz/quiz_cubit.dart';
-import 'package:quiz_master/features/quiz/presentation/pages/quiz_page.dart';
-import 'package:quiz_master/features/quiz/presentation/widgets/home_button.dart'
-    show HomeButton;
+import 'package:quiz_master/features/quiz/presentation/widgets/home_button.dart';
 import 'package:quiz_master/features/quiz/presentation/widgets/quiz_answer_review.dart';
 import 'package:quiz_master/features/quiz/presentation/widgets/quiz_summary_stats.dart';
 import 'package:quiz_master/l10n/app_localizations.dart';
+import 'package:quiz_master/utils/helpers.dart';
 
 class QuizSummary extends StatefulWidget {
   final int score;
@@ -105,11 +101,7 @@ class _QuizSummaryState extends State<QuizSummary>
                     Navigator.pushReplacement(
                       context,
                       MaterialPageRoute(
-                        builder: (_) => BlocProvider(
-                          create: (_) =>
-                              sl<QuizCubit>()..loadQuiz(QuizParams(amount: 10)),
-                          child: QuizPage(),
-                        ),
+                        builder: (_) => LevelingDifficultyPage(),
                       ),
                     );
                   },
@@ -158,7 +150,7 @@ class _QuizSummaryState extends State<QuizSummary>
               ),
               const SizedBox(height: 16),
               Text(
-                "${AppLocalizations.of(context)!.keepPracticing} 💪",
+                Helpers.getResultText(context, percentage),
                 style: const TextStyle(
                   color: Colors.white,
                   fontSize: 28,

--- a/lib/features/quiz/presentation/widgets/quiz_summary.dart
+++ b/lib/features/quiz/presentation/widgets/quiz_summary.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:quiz_master/features/leveling/data/constants/difficulties.dart';
 import 'package:quiz_master/features/leveling/presentation/pages/leveling_difficulty_page.dart';
 import 'package:quiz_master/features/quiz/domain/entity/question.dart';
 import 'package:quiz_master/features/quiz/presentation/widgets/home_button.dart';
@@ -15,6 +16,7 @@ class QuizSummary extends StatefulWidget {
   final List<int> answerTimes;
   final List<Question> questions;
   final List<String?> userAnswers;
+  final Difficulties difficulty;
 
   const QuizSummary({
     super.key,
@@ -24,6 +26,7 @@ class QuizSummary extends StatefulWidget {
     required this.answerTimes,
     required this.questions,
     required this.userAnswers,
+    required this.difficulty,
   });
 
   @override
@@ -67,6 +70,7 @@ class _QuizSummaryState extends State<QuizSummary>
             const SizedBox(height: 24),
             QuizSummaryStats(
               score: widget.score,
+              difficulty: widget.difficulty,
               totalQuestions: widget.totalQuestions,
               totalTime: widget.totalTime,
               answerTimes: widget.answerTimes,

--- a/lib/features/quiz/presentation/widgets/quiz_summary_stats.dart
+++ b/lib/features/quiz/presentation/widgets/quiz_summary_stats.dart
@@ -1,21 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:quiz_master/core/presentation/widgets/responsive.dart';
+import 'package:quiz_master/di.dart';
+import 'package:quiz_master/features/leveling/data/constants/difficulties.dart';
+import 'package:quiz_master/features/leveling/presentation/blocs/user_level/user_level_bloc.dart';
 import 'package:quiz_master/l10n/app_localizations.dart';
 import 'package:quiz_master/utils/helpers.dart';
 
 class QuizSummaryStats extends StatelessWidget {
   final int score;
-  final int totalQuestions;
   final Duration totalTime;
   final List<int> answerTimes;
+  final Difficulties difficulty;
+  final int totalQuestions;
 
   const QuizSummaryStats({
     super.key,
     required this.score,
-    required this.totalQuestions,
     required this.totalTime,
     required this.answerTimes,
+    required this.difficulty,
+    required this.totalQuestions,
   });
 
   @override
@@ -23,9 +28,19 @@ class QuizSummaryStats extends StatelessWidget {
     final accuracy = totalQuestions > 0
         ? (score / totalQuestions * 100).round()
         : 0;
+
     final avgTimePerQuestion = answerTimes.isNotEmpty
         ? answerTimes.reduce((a, b) => a + b) ~/ answerTimes.length
         : 0;
+
+    final experienceEarned = Helpers.calculateXp(
+      accuracy: accuracy / 100,
+      avgAnswerTime: avgTimePerQuestion.toDouble(),
+      totalQuestions: totalQuestions,
+      difficultyMultiplier: difficulty.multiplier,
+    );
+
+    sl<UserLevelBloc>().add(AddXp(experienceEarned.toInt()));
 
     Widget buildStatTile(
       IconData icon,
@@ -94,12 +109,12 @@ class QuizSummaryStats extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              buildStatTile(
-                FontAwesomeIcons.circleCheck,
-                AppLocalizations.of(context)!.accuracy,
-                "$accuracy%",
-                Colors.deepPurpleAccent,
-              ),
+              // buildStatTile(
+              //   FontAwesomeIcons.circleCheck,
+              //   AppLocalizations.of(context)!.accuracy,
+              //   "$accuracy%",
+              //   Colors.deepPurpleAccent,
+              // ),
               buildStatTile(
                 FontAwesomeIcons.clock,
                 AppLocalizations.of(context)!.totalTime,
@@ -120,14 +135,14 @@ class QuizSummaryStats extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Expanded(
-                child: buildStatTile(
-                  FontAwesomeIcons.circleCheck,
-                  AppLocalizations.of(context)!.accuracy,
-                  "$accuracy%",
-                  Colors.deepPurpleAccent,
-                ),
-              ),
+              // Expanded(
+              //   child: buildStatTile(
+              //     FontAwesomeIcons.circleCheck,
+              //     AppLocalizations.of(context)!.accuracy,
+              //     "$accuracy%",
+              //     Colors.deepPurpleAccent,
+              //   ),
+              // ),
               Expanded(
                 child: buildStatTile(
                   FontAwesomeIcons.clock,
@@ -154,26 +169,38 @@ class QuizSummaryStats extends StatelessWidget {
             children: [
               Expanded(
                 child: buildStatTile(
-                  FontAwesomeIcons.circleCheck,
-                  AppLocalizations.of(context)!.accuracy,
-                  "$accuracy%",
+                  FontAwesomeIcons.clock,
+                  AppLocalizations.of(context)!.totalTime,
+                  "${totalTime.inMinutes}m ${totalTime.inSeconds % 60}s",
                   Colors.deepPurpleAccent,
                 ),
               ),
               Expanded(
                 child: buildStatTile(
-                  FontAwesomeIcons.clock,
-                  AppLocalizations.of(context)!.totalTime,
-                  "${totalTime.inMinutes}m ${totalTime.inSeconds % 60}s",
+                  FontAwesomeIcons.brain,
+                  AppLocalizations.of(context)!.avgTime,
+                  "${avgTimePerQuestion}s",
                   Colors.teal,
                 ),
               ),
               Expanded(
                 child: buildStatTile(
+                  FontAwesomeIcons.solidStar,
+                  AppLocalizations.of(context)!.experienceEarned,
+                  experienceEarned.toStringAsFixed(0),
+                  Colors.orangeAccent,
+                ),
+              ),
+              Expanded(
+                child: buildStatTile(
                   FontAwesomeIcons.bolt,
-                  AppLocalizations.of(context)!.avgTime,
-                  "${avgTimePerQuestion}s",
-                  Colors.teal,
+                  AppLocalizations.of(context)!.difficulty,
+                  difficulty.title,
+                  difficulty.apiValue == 'easy'
+                      ? Colors.green
+                      : difficulty.apiValue == 'medium'
+                      ? Colors.yellow
+                      : Colors.red,
                 ),
               ),
             ],

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -48,5 +48,7 @@
     "resultVeryPoor": "Don’t give up! 💫",
     "experienceEarned": "XP Earned",
     "difficulty": "Difficulty",
-    "level": "Level"
+    "level": "Level",
+    "browse": "Browse",
+    "achievements": "Achievements"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -45,5 +45,8 @@
     "resultGood": "Well done! 👍",
     "resultAverage": "Not bad! 💪",
     "resultPoor": "Keep practicing! 📚",
-    "resultVeryPoor": "Don’t give up! 💫"
+    "resultVeryPoor": "Don’t give up! 💫",
+    "experienceEarned": "XP Earned",
+    "difficulty": "Difficulty",
+    "level": "Level"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -20,7 +20,6 @@
     "chooseYourCategoryDesc": "Select a topic and start your quiz journey",
     "home": "Home",
     "error": "Error",
-    "keepPracticing": "Keep Practicing!",
     "correct": "Correct",
     "accuracy": "Accuracy",
     "totalTime": "Total Time",
@@ -32,5 +31,19 @@
     "playAgain": "Play Again",
     "question": "Question",
     "questionOf": "of",
-    "skip": "Skip"
+    "skip": "Skip",
+    "difficultyEasy": "Easy",
+    "difficultyEasyDescription": "Perfect for beginners and casual learning",
+    "difficultyMedium": "Medium",
+    "difficultyMediumDescription": "A balanced challenge for most players",
+    "difficultyHard": "Hard",
+    "difficultyHardDescription": "For experts seeking maximum challenge",
+    "chooseYourDifficulty": "Choose Your Difficulty",
+    "chooseYourDifficultyDesc": "Higher difficulty means more XP rewards!",
+    "resultExcellent": "Outstanding! 🏆",
+    "resultVeryGood": "Great job! 🌟",
+    "resultGood": "Well done! 👍",
+    "resultAverage": "Not bad! 💪",
+    "resultPoor": "Keep practicing! 📚",
+    "resultVeryPoor": "Don’t give up! 💫"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -375,6 +375,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Don’t give up! 💫'**
   String get resultVeryPoor;
+
+  /// No description provided for @experienceEarned.
+  ///
+  /// In en, this message translates to:
+  /// **'XP Earned'**
+  String get experienceEarned;
+
+  /// No description provided for @difficulty.
+  ///
+  /// In en, this message translates to:
+  /// **'Difficulty'**
+  String get difficulty;
+
+  /// No description provided for @level.
+  ///
+  /// In en, this message translates to:
+  /// **'Level'**
+  String get level;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -393,6 +393,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Level'**
   String get level;
+
+  /// No description provided for @browse.
+  ///
+  /// In en, this message translates to:
+  /// **'Browse'**
+  String get browse;
+
+  /// No description provided for @achievements.
+  ///
+  /// In en, this message translates to:
+  /// **'Achievements'**
+  String get achievements;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -220,12 +220,6 @@ abstract class AppLocalizations {
   /// **'Error'**
   String get error;
 
-  /// No description provided for @keepPracticing.
-  ///
-  /// In en, this message translates to:
-  /// **'Keep Practicing!'**
-  String get keepPracticing;
-
   /// No description provided for @correct.
   ///
   /// In en, this message translates to:
@@ -297,6 +291,90 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Skip'**
   String get skip;
+
+  /// No description provided for @difficultyEasy.
+  ///
+  /// In en, this message translates to:
+  /// **'Easy'**
+  String get difficultyEasy;
+
+  /// No description provided for @difficultyEasyDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Perfect for beginners and casual learning'**
+  String get difficultyEasyDescription;
+
+  /// No description provided for @difficultyMedium.
+  ///
+  /// In en, this message translates to:
+  /// **'Medium'**
+  String get difficultyMedium;
+
+  /// No description provided for @difficultyMediumDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'A balanced challenge for most players'**
+  String get difficultyMediumDescription;
+
+  /// No description provided for @difficultyHard.
+  ///
+  /// In en, this message translates to:
+  /// **'Hard'**
+  String get difficultyHard;
+
+  /// No description provided for @difficultyHardDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'For experts seeking maximum challenge'**
+  String get difficultyHardDescription;
+
+  /// No description provided for @chooseYourDifficulty.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose Your Difficulty'**
+  String get chooseYourDifficulty;
+
+  /// No description provided for @chooseYourDifficultyDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Higher difficulty means more XP rewards!'**
+  String get chooseYourDifficultyDesc;
+
+  /// No description provided for @resultExcellent.
+  ///
+  /// In en, this message translates to:
+  /// **'Outstanding! 🏆'**
+  String get resultExcellent;
+
+  /// No description provided for @resultVeryGood.
+  ///
+  /// In en, this message translates to:
+  /// **'Great job! 🌟'**
+  String get resultVeryGood;
+
+  /// No description provided for @resultGood.
+  ///
+  /// In en, this message translates to:
+  /// **'Well done! 👍'**
+  String get resultGood;
+
+  /// No description provided for @resultAverage.
+  ///
+  /// In en, this message translates to:
+  /// **'Not bad! 💪'**
+  String get resultAverage;
+
+  /// No description provided for @resultPoor.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep practicing! 📚'**
+  String get resultPoor;
+
+  /// No description provided for @resultVeryPoor.
+  ///
+  /// In en, this message translates to:
+  /// **'Don’t give up! 💫'**
+  String get resultVeryPoor;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -74,9 +74,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get error => 'Error';
 
   @override
-  String get keepPracticing => 'Keep Practicing!';
-
-  @override
   String get correct => 'Correct';
 
   @override
@@ -111,4 +108,50 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get skip => 'Skip';
+
+  @override
+  String get difficultyEasy => 'Easy';
+
+  @override
+  String get difficultyEasyDescription =>
+      'Perfect for beginners and casual learning';
+
+  @override
+  String get difficultyMedium => 'Medium';
+
+  @override
+  String get difficultyMediumDescription =>
+      'A balanced challenge for most players';
+
+  @override
+  String get difficultyHard => 'Hard';
+
+  @override
+  String get difficultyHardDescription =>
+      'For experts seeking maximum challenge';
+
+  @override
+  String get chooseYourDifficulty => 'Choose Your Difficulty';
+
+  @override
+  String get chooseYourDifficultyDesc =>
+      'Higher difficulty means more XP rewards!';
+
+  @override
+  String get resultExcellent => 'Outstanding! 🏆';
+
+  @override
+  String get resultVeryGood => 'Great job! 🌟';
+
+  @override
+  String get resultGood => 'Well done! 👍';
+
+  @override
+  String get resultAverage => 'Not bad! 💪';
+
+  @override
+  String get resultPoor => 'Keep practicing! 📚';
+
+  @override
+  String get resultVeryPoor => 'Don’t give up! 💫';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -163,4 +163,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get level => 'Level';
+
+  @override
+  String get browse => 'Browse';
+
+  @override
+  String get achievements => 'Achievements';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -154,4 +154,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get resultVeryPoor => 'Don’t give up! 💫';
+
+  @override
+  String get experienceEarned => 'XP Earned';
+
+  @override
+  String get difficulty => 'Difficulty';
+
+  @override
+  String get level => 'Level';
 }

--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -3,6 +3,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:quiz_master/core/presentation/blocs/page_index_cubit.dart';
 import 'package:quiz_master/core/presentation/widgets/responsive.dart';
 import 'package:quiz_master/di.dart';
+import 'package:quiz_master/features/browse/presentation/pages/browse_page.dart';
 import 'package:quiz_master/features/home/presentation/pages/home_page.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -13,7 +14,7 @@ class MainScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final pages = const [HomePage(), HomePage()];
+    final pages = const [HomePage(), BrowsePage(), HomePage()];
 
     return Responsive(
       mobile: BlocBuilder<PageIndexCubit, int>(
@@ -35,8 +36,12 @@ class MainScreen extends StatelessWidget {
                   label: AppLocalizations.of(context)!.home,
                 ),
                 BottomNavigationBarItem(
-                  icon: FaIcon(FontAwesomeIcons.school),
-                  label: 'Other',
+                  icon: FaIcon(FontAwesomeIcons.magnifyingGlass),
+                  label: AppLocalizations.of(context)!.browse,
+                ),
+                BottomNavigationBarItem(
+                  icon: FaIcon(FontAwesomeIcons.trophy),
+                  label: AppLocalizations.of(context)!.achievements,
                 ),
               ],
             ),
@@ -65,9 +70,13 @@ class MainScreen extends StatelessWidget {
                       icon: FaIcon(FontAwesomeIcons.solidHouse),
                       label: Text(AppLocalizations.of(context)!.home),
                     ),
-                    const NavigationRailDestination(
-                      icon: FaIcon(FontAwesomeIcons.school),
-                      label: Text('Other'),
+                    NavigationRailDestination(
+                      icon: FaIcon(FontAwesomeIcons.magnifyingGlass),
+                      label: Text(AppLocalizations.of(context)!.browse),
+                    ),
+                    NavigationRailDestination(
+                      icon: FaIcon(FontAwesomeIcons.trophy),
+                      label: Text(AppLocalizations.of(context)!.achievements),
                     ),
                   ],
                 ),
@@ -99,9 +108,13 @@ class MainScreen extends StatelessWidget {
                       icon: FaIcon(FontAwesomeIcons.solidHouse),
                       label: Text(AppLocalizations.of(context)!.home),
                     ),
-                    const NavigationRailDestination(
-                      icon: FaIcon(FontAwesomeIcons.school),
-                      label: Text('Other'),
+                    NavigationRailDestination(
+                      icon: FaIcon(FontAwesomeIcons.magnifyingGlass),
+                      label: Text(AppLocalizations.of(context)!.browse),
+                    ),
+                    NavigationRailDestination(
+                      icon: FaIcon(FontAwesomeIcons.trophy),
+                      label: Text(AppLocalizations.of(context)!.achievements),
                     ),
                   ],
                 ),

--- a/lib/utils/extensions.dart
+++ b/lib/utils/extensions.dart
@@ -1,0 +1,31 @@
+import 'package:quiz_master/features/leveling/data/constants/difficulties.dart';
+
+extension DifficultiesConfigExtension on Difficulties {
+  int get questionCount {
+    switch (apiValue) {
+      case 'easy':
+        return 8;
+      case 'medium':
+        return 10;
+      case 'hard':
+        return 12;
+      default:
+        return 10;
+    }
+  }
+
+  Duration get timePerQuestion {
+    switch (apiValue) {
+      case 'easy':
+        return const Duration(seconds: 20);
+      case 'medium':
+        return const Duration(seconds: 15);
+      case 'hard':
+        return const Duration(seconds: 10);
+      default:
+        return const Duration(seconds: 15);
+    }
+  }
+
+  double get scoreMultiplier => multiplier;
+}

--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -16,4 +16,28 @@ class Helpers {
     if (percentage >= 0.2) return l10n.resultPoor;
     return l10n.resultVeryPoor;
   }
+
+  static double calculateXp({
+    required double accuracy,
+    required double avgAnswerTime,
+    required int totalQuestions,
+    required double difficultyMultiplier,
+  }) {
+    const baseXpPerQuestion = 10.0;
+
+    final speedMultiplier = (10 / avgAnswerTime).clamp(1.0, 2.0);
+
+    double xp =
+        totalQuestions *
+        baseXpPerQuestion *
+        accuracy *
+        difficultyMultiplier *
+        speedMultiplier;
+
+    if (accuracy == 1.0) {
+      xp += 100 * difficultyMultiplier;
+    }
+
+    return xp.roundToDouble();
+  }
 }

--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -1,7 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:quiz_master/l10n/app_localizations.dart';
 
 class Helpers {
   static bool isDarkMode(BuildContext context) {
     return Theme.of(context).brightness == Brightness.dark;
+  }
+
+  static String getResultText(BuildContext context, double percentage) {
+    final l10n = AppLocalizations.of(context)!;
+
+    if (percentage >= 0.9) return l10n.resultExcellent;
+    if (percentage >= 0.75) return l10n.resultVeryGood;
+    if (percentage >= 0.6) return l10n.resultGood;
+    if (percentage >= 0.4) return l10n.resultAverage;
+    if (percentage >= 0.2) return l10n.resultPoor;
+    return l10n.resultVeryPoor;
   }
 }


### PR DESCRIPTION
This pull request introduces a new leveling feature to the app, refactors navigation flows for quiz play, and improves UI responsiveness and consistency. The most significant changes include the addition of user leveling logic, a difficulty selection page, and integration of leveling UI components throughout the app. Navigation to quizzes now routes through the new difficulty selection page, and responsive design improvements have been applied to key pages.

**Leveling Feature Implementation**
* Added a new `UserLevelBloc` with persistent state management, supporting XP accumulation, level calculation, and reset functionality (`user_level_bloc.dart`, `user_level_event.dart`, `user_level_state.dart`). [[1]](diffhunk://#diff-3c0f0abd0bfa4db4ea09a4ec5d783ce8a2d792470e7e8f594ef8fbb3b6d70628R1-R42) [[2]](diffhunk://#diff-6af34b37876e4dc9514025edd07877ac0ce144af0dbba9f6d86502634c1deb5eR1-R19) [[3]](diffhunk://#diff-b3e02bac58071e0a4d79f33ee6410f511c79726d2bd1b78ffce731562d17b38fR1-R27)
* Registered `UserLevelBloc` in the app's dependency injection setup to make it available throughout the app (`lib/di.dart`). [[1]](diffhunk://#diff-53c6d1d626a8df4509eadef6b2c1184a663c8fb1cfc00abfedfe4bc727329774R5) [[2]](diffhunk://#diff-53c6d1d626a8df4509eadef6b2c1184a663c8fb1cfc00abfedfe4bc727329774R28)
* Created a new `Difficulties` model and helper for difficulty options, supporting localization and icons (`difficulties.dart`).

**UI and Navigation Updates**
* Added `LevelCard` widget to the app bars of both `HomePage` and new `BrowsePage` for displaying user level information (`home_page.dart`, `browse_page.dart`). [[1]](diffhunk://#diff-8a7070cdd0274a7e73333e161563c889d6e61cb9748c302f5faaca66105e7592R2-R9) [[2]](diffhunk://#diff-8a7070cdd0274a7e73333e161563c889d6e61cb9748c302f5faaca66105e7592L39-R64) [[3]](diffhunk://#diff-1c801cad59332ba9ef2fcde50cc45e0d42f3d48431ac5f049da9a4c083d7f603R1-R82)
* Implemented a new `LevelingDifficultyPage` for selecting quiz difficulty before starting a game, with responsive layout and improved styling (`leveling_difficulty_page.dart`).

**Navigation Refactoring**
* Updated navigation from category selection and quick play to route through the new `LevelingDifficultyPage` instead of directly starting a quiz (`categories_section.dart`, `quick_play_button.dart`). [[1]](diffhunk://#diff-02a33031e7f68b52a87f5214a9497ed4e891a3a6b882d8acd2c4f90016af0f6fL177-R174) [[2]](diffhunk://#diff-e0819db3d1ec824430c2c7f48de65bbe2bd8fa1caa09780758e62486541b6f45L88-R84)

**Responsive Design Improvements**
* Refactored app bar paddings and spacing logic in `HomePage` and `BrowsePage` to use the shared `Responsive` widget for consistent appearance across devices (`home_page.dart`, `browse_page.dart`). [[1]](diffhunk://#diff-8a7070cdd0274a7e73333e161563c889d6e61cb9748c302f5faaca66105e7592L21-R27) [[2]](diffhunk://#diff-8a7070cdd0274a7e73333e161563c889d6e61cb9748c302f5faaca66105e7592L39-R64) [[3]](diffhunk://#diff-1c801cad59332ba9ef2fcde50cc45e0d42f3d48431ac5f049da9a4c083d7f603R1-R82)

**New Browse Page**
* Added a new `BrowsePage` with consistent app bar, gradient backgrounds, and leveling integration to support future content expansion (`browse_page.dart`).